### PR TITLE
Roll 20 update sheet & foundry Fixes

### DIFF
--- a/CreatureExport/FoundryCreatureHelper.cs
+++ b/CreatureExport/FoundryCreatureHelper.cs
@@ -44,7 +44,7 @@ namespace EncounterExport
                 var details = result.details;
                 details.bloodied = input.HP / 2;
                 details.surgeValue = input.HP / 4;
-                details.surges.value = (Math.Min(input.Level - 1, 1) / 10) + 1;
+                details.surges.value = (Math.Max(input.Level - 1, 1) / 10) + 1;
                 details.origin = input.Origin.ToString().ToLowerInvariant();
                 details.typeValue = input.Type.ToString().ToLowerInvariant();
                 details.level = input.Level;

--- a/CreatureExport/FoundryCreatureHelper.cs
+++ b/CreatureExport/FoundryCreatureHelper.cs
@@ -343,15 +343,16 @@ namespace EncounterExport
                 var vunerables = "";
                 foreach (var mod in input.DamageModifiers)
                 {
-                    var str = ", " + mod.Value + " " + mod.Type;
+                    var str = ", " + Math.Abs(mod.Value) + " " + mod.Type;
+                    var flippedVal = mod.Value * -1;
 
                     if (mod.Value < 0)
                     {
-                        resistances += str;
+                        vunerables += str;
                     }
                     else if (mod.Value > 0)
                     {
-                        vunerables += str;
+                        resistances += str;
                     }
 
 
@@ -366,7 +367,7 @@ namespace EncounterExport
                     {
                         var bonus = new Bonus()
                         {
-                            value = mod.Value,
+                            value = flippedVal,
                             name = "Monster"
                         };
                         damageMod.bonus.Add(bonus);

--- a/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
+++ b/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
@@ -35,6 +35,7 @@ namespace EncounterExport.FoundryHelpers
             "conjuration",
             "disease",
             "elemental",
+            "enchantment",
             "evocation",
             "fear",
             "fullDis",
@@ -346,8 +347,12 @@ namespace EncounterExport.FoundryHelpers
         private static void ProcessRangeAndWeapon(CreaturePower power, FoundryPowerData data, List<string> errors)
         {
             var range = power.Range;
-            // var weapon = data.keywords.Contains("weapon") || data.keywords.Contains("Weapon");
-            // var implement = data.keywords.Contains("implement") || data.keywords.Contains("Implement");
+            var weapon = data.keywords.Contains("weapon") || data.keywords.Contains("Weapon");
+            var implement = data.keywords.Contains("implement") || data.keywords.Contains("Implement");
+            if (implement)
+            {
+                data.weaponType = "implement";
+            }
             try
             {
                 var hasMatched = false;
@@ -358,6 +363,10 @@ namespace EncounterExport.FoundryHelpers
                         data.rangeType = "rangeBurst";
                         data.rangePower = Int32.Parse(match.Groups[2].Value);
                         data.area = Int32.Parse(match.Groups[1].Value);
+                        if (weapon)
+                        {
+                            data.weaponType = "range";
+                        }
                         hasMatched = true;
                     }
                 }
@@ -367,6 +376,10 @@ namespace EncounterExport.FoundryHelpers
                     {
                         data.rangeType = "closeBlast";
                         data.area = Int32.Parse(match.Groups[1].Value);
+                        if (weapon)
+                        {
+                            data.weaponType = "melee";
+                        }
                         hasMatched = true;
                     }
                 }
@@ -376,6 +389,10 @@ namespace EncounterExport.FoundryHelpers
                     {
                         data.rangeType = "closeBurst";
                         data.area = Int32.Parse(match.Groups[1].Value);
+                        if (weapon)
+                        {
+                            data.weaponType = "melee";
+                        }
                         hasMatched = true;
                     }
                 }
@@ -386,6 +403,10 @@ namespace EncounterExport.FoundryHelpers
                         data.rangeType = "melee";
                         data.rangePower = Int32.Parse(match.Groups[1].Value);
                         data.isMelee = true;
+                        if (weapon)
+                        {
+                            data.weaponType = "melee";
+                        }
                         hasMatched = true;
                     }
                 }
@@ -395,6 +416,10 @@ namespace EncounterExport.FoundryHelpers
                     {
                         data.rangeType = "range";
                         data.rangePower = Int32.Parse(match.Groups[1].Value);
+                        if (weapon)
+                        {
+                            data.weaponType = "range";
+                        }
                         hasMatched = true;
                     }
                 }
@@ -405,6 +430,10 @@ namespace EncounterExport.FoundryHelpers
                         data.rangeType = "reach";
                         data.rangePower = Int32.Parse(match.Groups[1].Value);
                         data.isMelee = true;
+                        if (weapon)
+                        {
+                            data.weaponType = "melee";
+                        }
                         hasMatched = true;
                     }
                 }

--- a/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
+++ b/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Masterplan.Data;
 
@@ -8,6 +9,20 @@ namespace EncounterExport.FoundryHelpers
 {
     public static class FoundryPowerHelper
     {
+        private static readonly char[] validIdChars = BuildIdCharsArray();
+        private static char[] BuildIdCharsArray()
+        {
+            StringBuilder builder = new StringBuilder();
+            Enumerable
+                .Range(65, 26)
+                .Select(e => ((char)e).ToString())
+                .Concat(Enumerable.Range(97, 26).Select(e => ((char)e).ToString()))
+                .Concat(Enumerable.Range(0, 10).Select(e => e.ToString()))
+                .OrderBy(e => Guid.NewGuid())
+                .ToList().ForEach(e => builder.Append(e));
+            return builder.ToString().ToCharArray();
+        }
+        
         private static readonly string[] ElementalDamageTypes =
         {
             "acid",
@@ -80,13 +95,24 @@ namespace EncounterExport.FoundryHelpers
             dict["nethermancy"] = "nether";
             return dict;
         }
+        
+        private static string newId(int length = 16) {
+            StringBuilder builder = new StringBuilder();
+            Random rnd = new Random();
+            for (int i = 0; i < length; i++)
+            {
+                builder.Append(validIdChars[rnd.Next(validIdChars.Length)]);
+            }
+            return builder.ToString();
+        }
             
         public static FoundryPower ProcessAction(CreaturePower power, List<string> errors,
             bool attackPower)
         {
             var resultPower = new FoundryPower
             {
-                name = power.Name
+                name = power.Name,
+                _id = newId()
             };
             var powerData = resultPower.data;
             powerData.keywords = power.Keywords.Split(CommonHelpers.separator, StringSplitOptions.RemoveEmptyEntries)

--- a/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
+++ b/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
@@ -144,7 +144,35 @@ namespace EncounterExport.FoundryHelpers
             powerData.rangeText = power.Range;
 
             powerData.target = power.Range;
-            powerData.rechargeRoll = power.Action.Recharge;
+            
+            powerData.rechargeCondition = power.Action.Recharge;
+            if (power.Action.Recharge != null)
+            {
+                switch (power.Action.Recharge)
+                {
+                    case PowerAction.RECHARGE_2: powerData.rechargeRoll = 2;
+                        break;
+                    case PowerAction.RECHARGE_3: powerData.rechargeRoll = 3;
+                        break;
+                    case PowerAction.RECHARGE_4: powerData.rechargeRoll = 4;
+                        break;
+                    case PowerAction.RECHARGE_5: powerData.rechargeRoll = 5;
+                        break;
+                    case PowerAction.RECHARGE_6: powerData.rechargeRoll = 6;
+                        break;
+                    default:
+                        try
+                        {
+                            powerData.rechargeRoll = Int32.Parse(power.Action.Recharge.Trim());
+                        }
+                        catch (Exception)
+                        {
+                            // do nothing, its probably a text condition
+                        }
+
+                        break;
+                }
+            }
 
             powerData.chatFlavor = power.Description;
             powerData.sustain.actionType = power.Action.SustainAction.ToString().ToLowerInvariant();

--- a/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
+++ b/CreatureExport/FoundryHelpers/FoundryPowerHelper.cs
@@ -205,6 +205,13 @@ namespace EncounterExport.FoundryHelpers
 
             // sometimes details are in the range field for traits
             powerData.effect.detail = string.IsNullOrEmpty(power.Details) ? power.Range : power.Details;
+            
+            // if however we now have an identical target and range should fix that to avoid duplicate descriptions
+            if (powerData.effect.detail == powerData.target)
+            {
+                powerData.target = null;
+            }
+            
             if (!attackPower)
             {
                 detailString += $"{powerData.effect.detail}";

--- a/CreatureExport/FoundryJSONClasses.cs
+++ b/CreatureExport/FoundryJSONClasses.cs
@@ -271,7 +271,8 @@ namespace EncounterExport
         public string rangeText { get; set; } = "";
         public int rangePower { get; set; }
         public int area { get; set; } = 0;
-        public string rechargeRoll { get; set; } = "";
+        public int? rechargeRoll { get; set; }
+        public string rechargeCondition { get; set; } = "";
         public bool damageShare { get; set; } = false;
         public bool postEffect { get; set; } = true;
         public bool postSpecial { get; set; } = true;

--- a/CreatureExport/FoundryJSONClasses.cs
+++ b/CreatureExport/FoundryJSONClasses.cs
@@ -199,6 +199,7 @@ namespace EncounterExport
     }
     public class FoundryPower
     {
+        public string _id { get; set; }
         public string name { get; set; }
         public string type { get; set; } = "power";
         public string img { get; set; } = "icons/svg/aura.svg";
@@ -209,6 +210,11 @@ namespace EncounterExport
     {
         public int Compare(FoundryPower x, FoundryPower y)
         {
+            if (x == null && y == null)
+            {
+                return 0;
+            } 
+            
             if (x == null)
             {
                 return 1;


### PR DESCRIPTION
Roll 20 scripts can now update a sheet in place (nuking all sheet attributes but keeping bio / tokens)

Fixes for foundry creatures:

* Resistance / Vulnerability being the wrong way round
* Added Enchantment keyword
* weapon/implement powers now have weapon/implement set to get the keyword
* removed duplicate power info when all data is in ranged details
* fixed number of surges for paragon / epic monsters